### PR TITLE
added support for subdirectories, smil files etc

### DIFF
--- a/src/remiheens/WowzaSecureToken/WowzaSecureToken.php
+++ b/src/remiheens/WowzaSecureToken/WowzaSecureToken.php
@@ -246,9 +246,24 @@ class WowzaSecureToken
             throw new WowzaException("Application or stream is invalid");
         }
 
-        $query = $pathItems[0] . "/" . $pathItems[1] . "?" . $query;
+        $path = "";
 
-        return strtr(base64_encode(hash($this->algorithms[$this->hashMethod], $query, true)),'+/','-_');
+        foreach ($pathItems as $k => $pathItem) {
+            if(false !== strpos($pathItem, 'm3u8')) {
+                break;
+            }
+            $path .= $pathItem;
+            if(count($pathItems)-1 != $k) {
+                $path .= '/';
+            }
+        }
+        if(strrpos($path, '/') === strlen($path)-1) {
+            $path = substr($path, 0, -1);
+        }
+
+        $path .= "?".$query;
+
+        return strtr(base64_encode(hash($this->algorithms[$this->hashMethod], $path, true)),'+/','-_');
     }
     
     /**


### PR DESCRIPTION
Hi,
The tokens generated did not generate the correct path for usage with subdirectories in the wowza content folder.

The applied fix should work with all directory structures, but might meed improvement for not using the smil suffixes for e.v. playlist.m3u8 etc.